### PR TITLE
<doc>避免因部署顺序导致prometheus部署失败[issue 2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ kubectl apply -f kube-controller-schedule/
 kubectl apply -f kube-state-metrics/
 kubectl apply -f grafana/
 kubectl apply -f WeChat/
-kubectl apply -f prometheus/
 kubectl apply -f alertmanager/
+kubectl apply -f prometheus/
 ```
 
 你可以使用ip:端口来访问，这些分别是


### PR DESCRIPTION
按照文档中默认部署顺序，如果先部署`prometheus`的话，`Deployment: k8s-pgmon-prometheus`将会部署失败，并提示如下错误：

```
MountVolume.SetUp failed for volume "k8s-pgmon-rules" : configmap "k8s-pgmon-rules" not found
```

`configmap: k8s-pgmon-rules`创建于`alertmanager/alertmanager-configMapRules.yaml`下，应该先部署`alertmanager`，再部署`prometheus`。

Issue #2
Close #2